### PR TITLE
Add support for i128/u128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "serde-transcode"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 license = "MIT/Apache-2.0"
 description = "Transcode from one Serde format to another"
 repository = "https://github.com/sfackler/serde-transcode"
-documentation = "https://docs.rs/serde-transcode/1.0.1/serde_transcode"
+documentation = "https://docs.rs/serde-transcode/1.1.0/serde_transcode"
 readme = "README.md"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 #![warn(missing_docs)]
 #![doc(html_root_url="https://docs.rs/serde-transcode/1.0.1")]
 
+#[macro_use]
 extern crate serde;
 
 use serde::de;
@@ -145,6 +146,20 @@ impl<'de, S> de::Visitor<'de> for Visitor<S>
         where E: de::Error
     {
         self.0.serialize_u64(v).map_err(s2d)
+    }
+
+    serde_if_integer128! {
+        fn visit_i128<E>(self, v: i128) -> Result<S::Ok, E>
+            where E: de::Error
+        {
+            self.0.serialize_i128(v).map_err(s2d)
+        }
+
+        fn visit_u128<E>(self, v: u128) -> Result<S::Ok, E>
+            where E: de::Error
+        {
+            self.0.serialize_u128(v).map_err(s2d)
+        }
     }
 
     fn visit_f32<E>(self, v: f32) -> Result<S::Ok, E>

--- a/src/test.rs
+++ b/src/test.rs
@@ -90,6 +90,24 @@ fn u64() {
     test(u32::max_value() as u64 + 1);
 }
 
+serde_if_integer128! {
+    #[test]
+    fn i128() {
+        // JSON not support too large numbers
+        test(i64::min_value() as i128);
+        test(0i128);
+        // JSON not support too large numbers
+        test(i64::max_value() as i128 + 1);
+    }
+
+    #[test]
+    fn u128() {
+        test(0u128);
+        // JSON not support too large numbers
+        test(u32::max_value() as u128 + 1);
+    }
+}
+
 #[test]
 fn f32() {
     test(1.3f32);


### PR DESCRIPTION
~I try to hide this behind feature flag but I do not find how to do this. serde itself has no feature for enabling `i128/u128`. So if this required and anybody knows how to do this, just say and I update PR~

Seems like feature not necessary