### PR TITLE
Added a more specific error message for failed transcoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,12 @@ impl<'de, D> ser::Serialize for Transcoder<D>
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: ser::Serializer
     {
-        self.0.borrow_mut().take().unwrap().deserialize_any(Visitor(s)).map_err(d2s)
+        self.0
+            .borrow_mut()
+            .take()
+            .expect("Transcoder could not serialize the input because its internal state was already advanced https://docs.rs/serde-transcode/1.1.0/serde_transcode/struct.Transcoder.html#note")
+            .deserialize_any(Visitor(s))
+            .map_err(d2s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl<'de, D> ser::Serialize for Transcoder<D>
         self.0
             .borrow_mut()
             .take()
-            .expect("Transcoder could not serialize the input because its internal state was already advanced https://docs.rs/serde-transcode/1.1.0/serde_transcode/struct.Transcoder.html#note")
+            .expect("Transcoder may only be serialized once")
             .deserialize_any(Visitor(s))
             .map_err(d2s)
     }


### PR DESCRIPTION
I'm not sure if putting a link to documentation in a panic message makes a whole lot of sense. Happy to format this in a way you think works better

Fixes #10 